### PR TITLE
Update skeleton to django 1.11

### DIFF
--- a/login/views.py
+++ b/login/views.py
@@ -2,7 +2,7 @@ from login.forms import *
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import logout
 from django.views.decorators.csrf import csrf_protect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.http import HttpResponseRedirect
 from django.template import RequestContext
 
@@ -20,20 +20,13 @@ def register(request):
             return HttpResponseRedirect('/account/register/success/')
     else:
         form = RegistrationForm()
-    variables = RequestContext(request, {
-        'form': form
-    })
+    variables = {'form': form}
 
-    return render_to_response(
-        'registration/register.html',
-        variables,
-    )
+    return render(request, 'registration/register.html', variables)
 
 
 def register_success(request):
-    return render_to_response(
-        'registration/success.html',
-    )
+    return render(request, 'registration/success.html')
 
 
 def logout_page(request):
@@ -43,7 +36,4 @@ def logout_page(request):
 
 @login_required
 def home(request):
-    return render_to_response(
-        'index.html',
-        {'user': request.user}
-    )
+    return render(request, 'index.html', {'user': request.user})

--- a/login/views.py
+++ b/login/views.py
@@ -4,7 +4,6 @@ from django.contrib.auth import logout
 from django.views.decorators.csrf import csrf_protect
 from django.shortcuts import render
 from django.http import HttpResponseRedirect
-from django.template import RequestContext
 
 
 @csrf_protect

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
-appdirs==1.4.3
 Django==1.11.1
-packaging==16.8
-pyparsing==2.2.0
-pytz==2017.2
-six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
-Django==1.10.4
+appdirs==1.4.3
+Django==1.11.1
+packaging==16.8
+pyparsing==2.2.0
+pytz==2017.2
+six==1.10.0


### PR DESCRIPTION
I updated the skeleton to be compatible with Django 1.11.

The RequestContext was outdated anyway so I changed the render_to_response() calls to the render() calls.
render_to_response() is inferior according to the django documentation and should not be used anymore. 